### PR TITLE
updated anbox-modules-dkms to support 6.xx kernel

### DIFF
--- a/anbox-modules-dkms/PKGBUILD
+++ b/anbox-modules-dkms/PKGBUILD
@@ -16,10 +16,12 @@ depends=('dkms')
 makedepends=('git')
 source=("git+https://github.com/choff/${_pkgname}.git#commit=8148a162755bf5500a07cf41a65a02c8f3eb0af9"
   "https://github.com/sickcodes/anbox-modules/commit/7c19d3c66758747d854c63e4c34ef127ce201fa6.patch"
-  "https://github.com/choff/anbox-modules/pull/4.patch")
+  "https://github.com/choff/anbox-modules/pull/4.patch"
+  "linux-6.patch")
 sha256sums=('SKIP'
             '7589f311fd9a503c30a214b54f1f687c26a2f160d4339098c65f655e9b1e3556'
-            'fced11f849692dd1f0f36b50bb859d85aa244a536c2cef529a14bb73f568bb5e')
+            'fced11f849692dd1f0f36b50bb859d85aa244a536c2cef529a14bb73f568bb5e'
+            'SKIP')
 conflicts=(anbox-modules-dkms-git)
 
 prepare() {
@@ -31,6 +33,8 @@ prepare() {
   # # Patch for 5.19
   patch -p1 -i "${srcdir}"/4.patch
 
+  # # Patch for kernel 6.xx
+  patch --forward --strip=1 --input="${srcdir}/linux-6.patch"
 }
 
 package() {

--- a/anbox-modules-dkms/linux-6.patch
+++ b/anbox-modules-dkms/linux-6.patch
@@ -1,0 +1,40 @@
+diff --color --unified --recursive --text src/anbox-modules/ashmem/ashmem.c src-modified/anbox-modules/ashmem/ashmem.c
+--- anbox-modules/ashmem/ashmem.c	2022-10-15 23:50:53.701157821 -0300
++++ anbox-modules/ashmem/ashmem.c	2022-10-15 23:40:35.259339844 -0300
+@@ -874,7 +874,11 @@
+ 		return ret;
+ 	}
+ 
+-	register_shrinker(&ashmem_shrinker);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0))
++         register_shrinker(&ashmem_shrinker, "ashmem");
++#else
++         register_shrinker(&ashmem_shrinker);
++#endif
+ 
+ 	return 0;
+ }
+diff --color --unified --recursive --text src/anbox-modules/binder/binder_alloc.c src-modified/anbox-modules/binder/binder_alloc.c
+--- anbox-modules/binder/binder_alloc.c	2022-10-15 23:50:53.714491337 -0300
++++ anbox-modules/binder/binder_alloc.c	2022-10-15 23:38:19.997484771 -0300
+@@ -23,6 +23,7 @@
+ #include <linux/uaccess.h>
+ #include <linux/highmem.h>
+ #include <linux/sizes.h>
++#include <linux/version.h>
+ #include "binder_alloc.h"
+ #include "binder_trace.h"
+ 
+@@ -1079,7 +1080,11 @@
+ 	int ret = list_lru_init(&binder_alloc_lru);
+ 
+ 	if (ret == 0) {
+-		ret = register_shrinker(&binder_shrinker);
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0))
++                ret = register_shrinker(&binder_shrinker, "binder");
++#else
++                ret = register_shrinker(&binder_shrinker);
++#endif
+ 		if (ret)
+ 			list_lru_destroy(&binder_alloc_lru);
+ 	}


### PR DESCRIPTION
Hello, I saw this comment in the AUR https://aur.archlinux.org/packages/anbox-modules-dkms#comment-885078 and decided to give it a try.

However, it did not work because the file `ashmem.c` also needed updating, so I did it.